### PR TITLE
Corrigindo erro ao buscar a lista de perfis favoritos do Github

### DIFF
--- a/JS/fav.js
+++ b/JS/fav.js
@@ -6,7 +6,7 @@ export class Favorites {
     this.load();
   }
   load() {
-    this.DadosUsers = JSON.parse(localStorage.getItem("@github-favorites:"));
+    this.DadosUsers = JSON.parse(localStorage.getItem("@github-favorites:")) || [];
   }
 
   save(){


### PR DESCRIPTION
Salve Lucas.

Adorei a ideia do seu projeto. Fiquei curioso para ver funcionando e resolvi abrir o deploy no Github pages. Ficou muito bom por sinal. Porém vi no console do navegador um erro. E decidi ajudar com meus 0.25 centavos. Espero que não se importe.
Deixei um commit explicando melhor minha alteração.

Se não for abuso, eu tive uma ideia para complementar o projeto. Seria interessante que ao começar a pesquisar o nome dos perfis aparecesse uma lista com sugestões de nomes. Se quiser posso ajudar com isso. Mas é só uma ideia :wink:.